### PR TITLE
FE-57: Update ServersProvider to support asynchronous actions

### DIFF
--- a/components/Servers_Channels/ServerList.tsx
+++ b/components/Servers_Channels/ServerList.tsx
@@ -15,10 +15,11 @@ import Toggle from '../Toggle';
 import useServers from '@/hooks/useServers';
 
 const ServerList = () => {
-  const { setServers } = useServers();
+  const { servers, setServers, selectServer } = useServers();
   const ref = useRef<BottomSheet>(null);
   const snapPoints = useMemo(() => [85, '95%'], []);
   const [currentIndex, setCurrentIndex] = useState(0);
+  const [isInitialMount, setIsInitialMount] = useState(true);
 
   const handleSheetChanges = (index: number) => {
     setCurrentIndex(index);
@@ -30,13 +31,19 @@ const ServerList = () => {
 
   useEffect(() => {
     // Fetch data (servers)
-    setServers(
-      Array.from({ length: 30 }, (_, i) => ({
-        id: i.toString(),
-        name: `Server ${i}`
-      }))
-    );
+    const newServers = Array.from({ length: 30 }, (_, i) => ({
+      id: i.toString(),
+      name: `Server ${i}`
+    }));
+    setServers(newServers);
   }, []);
+
+  useEffect(() => {
+    if (servers && servers.length > 0 && isInitialMount) {
+      selectServer(servers[0].id);
+      setIsInitialMount(false);
+    }
+  }, [servers]);
 
   const renderBackdrop = useCallback(
     (props: any) => (

--- a/components/modal/CreateServerModal.tsx
+++ b/components/modal/CreateServerModal.tsx
@@ -4,7 +4,7 @@ import {
   TouchableWithoutFeedback,
   View
 } from 'react-native';
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import MyText from '../MyText';
 import { TextStyles } from '@/styles/TextStyles';
 import { colors } from '@/constants/theme';
@@ -21,16 +21,25 @@ export interface CreateServerModalProps {
 const CreateServerModal = (props: CreateServerModalProps) => {
   const { servers, setServers, selectServer } = useServers();
   const [serverName, setServerName] = useState('');
+  const [newServerId, setNewServerId] = useState('');
 
   const handleConfirm = () => {
     // Create server here
-    setServers(
-      [{ id: servers.length.toString(), name: serverName }, ...servers],
-      false,
-      true
-    );
+    const newServers = [
+      { id: servers.length.toString(), name: serverName },
+      ...servers
+    ];
+    setServers(newServers, false, true);
+    setNewServerId(newServers[0].id);
     props.onClose(true);
   };
+
+  useEffect(() => {
+    if (newServerId) {
+      selectServer(newServerId);
+      setNewServerId('');
+    }
+  }, [servers]);
 
   return (
     <Modal

--- a/context/ServersProvider.tsx
+++ b/context/ServersProvider.tsx
@@ -1,10 +1,13 @@
 import { Server } from '@/types';
-import { createContext, ReactNode, useReducer } from 'react';
+import { createContext, ReactNode, useEffect, useReducer, useRef } from 'react';
 
 // Types
 enum Actions {
   SELECT_SERVER = 'SELECT_SERVER',
-  SET_SERVERS = 'SET_SERVERS'
+  SET_SERVERS = 'SET_SERVERS',
+  SET_CATEGORIES = 'SET_CATEGORIES',
+  SET_MEMBERS = 'SET_MEMBERS',
+  SET_ROLES = 'SET_ROLES'
 }
 
 type Channel = {
@@ -18,10 +21,24 @@ type Category = {
   channels: Channel[];
 };
 
+type Member = {
+  id: string;
+  username: string;
+  avatar?: string;
+};
+
+type Role = {
+  id: string;
+  name: string;
+  color: string;
+};
+
 type ServersState = {
   servers: Server[];
   currentServerId: string | null;
   categories: Category[];
+  members: Member[];
+  roles: Role[];
 };
 
 type ServerAction = {
@@ -36,6 +53,7 @@ interface IServersContext extends ServersState {
     isForPositions?: boolean,
     isNewServer?: boolean
   ) => void;
+  dispatch: React.Dispatch<ServerAction>;
 }
 
 interface ServersProviderProps {
@@ -46,14 +64,17 @@ interface ServersProviderProps {
 const initialState: ServersState = {
   servers: [],
   currentServerId: null,
-  categories: []
+  categories: [],
+  members: [],
+  roles: []
 };
 
 // Context
 export const ServersContext = createContext<IServersContext>({
   ...initialState,
   selectServer: () => {},
-  setServers: () => {}
+  setServers: () => {},
+  dispatch: () => {}
 });
 
 // Handlers
@@ -62,42 +83,33 @@ const handlers: Record<
   (state: ServersState, action: ServerAction) => ServersState
 > = {
   [Actions.SELECT_SERVER]: (state, { payload }) => {
-    // fetch server with id provided
-    const categories: Category[] = Array.from({ length: 5 }, (_, i) => ({
-      id: i.toString(),
-      name: i ? `Category ${i}` : `Uncategorized`,
-      channels: Array.from({ length: 5 }, (_, j) => ({
-        id: j.toString(),
-        name: `Channel ${j}`
-      }))
-    }));
-
     return {
       ...state,
-      currentServerId: payload,
-      categories
+      currentServerId: payload
     };
   },
   [Actions.SET_SERVERS]: (state, { payload: { newServers, isNewServer } }) => {
-    // fetch server with id provided
-    const categories: Category[] = Array.from({ length: 5 }, (_, i) => ({
-      id: i.toString(),
-      name: i ? `Category ${i}` : `Uncategorized`,
-      channels: Array.from({ length: 5 }, (_, j) => ({
-        id: j.toString(),
-        name: `Channel ${j}`
-      }))
-    }));
     return {
       ...state,
-      servers: newServers,
-      currentServerId:
-        newServers.length === 0
-          ? null
-          : state.servers.length === 0 || isNewServer
-          ? newServers[0].id
-          : state.currentServerId,
-      categories
+      servers: newServers
+    };
+  },
+  [Actions.SET_CATEGORIES]: (state, { payload }) => {
+    return {
+      ...state,
+      categories: payload
+    };
+  },
+  [Actions.SET_MEMBERS]: (state, { payload }) => {
+    return {
+      ...state,
+      members: payload
+    };
+  },
+  [Actions.SET_ROLES]: (state, { payload }) => {
+    return {
+      ...state,
+      roles: payload
     };
   }
 };
@@ -114,12 +126,36 @@ const reducer = (state: ServersState, action: ServerAction) => {
 // Provider
 export const ServersProvider = ({ children }: ServersProviderProps) => {
   const [state, dispatch] = useReducer(reducer, initialState);
-
-  const selectServer = (id: string) => {
+  const selectServer = async (id: string) => {
     // Fetch server id
     if (state.servers.findIndex((server) => server.id === id) === -1) {
       throw new Error(`Server with id ${id} not found`);
     }
+    // fetch server with id provided
+    const categories: Category[] = Array.from({ length: 5 }, (_, i) => ({
+      id: i.toString(),
+      name: i ? `Category ${i}` : `Uncategorized`,
+      channels: Array.from({ length: 5 }, (_, j) => ({
+        id: j.toString(),
+        name: `Channel ${j}`
+      }))
+    }));
+
+    const members: Member[] = Array.from({ length: 10 }, (_, i) => ({
+      id: i.toString(),
+      username: `user_${i}`
+    }));
+
+    const roles: Role[] = Array.from({ length: 10 }, (_, i) => ({
+      id: i.toString(),
+      name: `role_${i}`,
+      color: `#${
+        Math.floor(Math.random() * 16777215).toString(16) // random color
+      }`
+    }));
+    dispatch({ type: Actions.SET_CATEGORIES, payload: categories });
+    dispatch({ type: Actions.SET_MEMBERS, payload: members });
+    dispatch({ type: Actions.SET_ROLES, payload: roles });
     dispatch({ type: Actions.SELECT_SERVER, payload: id });
   };
 
@@ -137,7 +173,14 @@ export const ServersProvider = ({ children }: ServersProviderProps) => {
   };
 
   return (
-    <ServersContext.Provider value={{ ...state, selectServer, setServers }}>
+    <ServersContext.Provider
+      value={{
+        ...state,
+        selectServer,
+        setServers,
+        dispatch
+      }}
+    >
       {children}
     </ServersContext.Provider>
   );


### PR DESCRIPTION
# What?
The previous `ServersProvider` does not fully support asynchronous calls and introduces code duplication. This PR involves implementing in a way that addresses those problems.

# How?
To avoid asynchronous calls inside reducer functions, the async calls are moved outside of the reducer, and let the responsibility to the function that dispatches those actions.
To avoid code duplication, the responsibility of selecting a new server after setting servers is moved to the screens calling it.