### PR TITLE
FE-70: Implement Rich Text Editor

### DIFF
--- a/app/subPlayground.tsx
+++ b/app/subPlayground.tsx
@@ -56,6 +56,7 @@ const subPlayground = () => {
         onChange={setText}
         mentions={['nhanbin03', 'role 1', 'role 1 lorem ipsum']}
         emojis={['kekw', 'pepega', 'pog']}
+        channels={['Channel 1', 'Channel 2', 'Channel 1 extra']}
       />
     </KeyboardAvoidingView>
   );


### PR DESCRIPTION
# What?
This PR involves implementing the Rich Text Editor of the input bar. This feature is inspired by the Discord Mobile app, thus it may not contain the features that Discord Desktop provides. As a result, the Rich Text Editor only supports highlighting specific patterns like mentions and emoji. Note that it will not replace the text with actual emojis, nor can it allow users to delete a whole pattern text like on a PC.

# How?
To specify the words to highlight, we can pass the array of mention/emoji names into the component props. For example:
```
<ChatInput
  value={text}
  onChange={setText}
  mentions={['nhanbin03', 'role 1', 'role 1 lorem ipsum']}
  emojis={['kekw', 'pepega', 'pog']}
/>
```
# Screenshots
![image](https://github.com/user-attachments/assets/820baa38-ab41-46e8-b04a-62014901c995)


      