### PR TITLE
SE-23: Fix fetch message history bug

### DIFF
--- a/app/conversation/channel/[channelId]/index.tsx
+++ b/app/conversation/channel/[channelId]/index.tsx
@@ -95,10 +95,13 @@ const ChannelConversation = () => {
   });
 
   const [loading, setLoading] = useState(false);
+  const [messageEndReached, setMessageEndReached] = useState(false);
 
   const fetchMessages = async () => {
     if (!conversation) return;
     if (conversation.messages.length === 0) return;
+    if (messageEndReached) return;
+    if (loading) return;
     setLoading(true);
     const response = await getData(
       `/api/v1/servers/${currentServerId}/channels/${channelId}/messages`,
@@ -108,6 +111,9 @@ const ChannelConversation = () => {
         limit: 10
       }
     );
+    if (response.messages.length === 0) {
+      setMessageEndReached(true);
+    }
     conversationDispatch({
       type: ConversationsTypes.AddConversationMessageHistory,
       payload: {
@@ -135,7 +141,6 @@ const ChannelConversation = () => {
         }
       }
     });
-    if (conversation && conversation.messages.length < 10) fetchMessages();
     return () => {
       conversationDispatch({
         type: ConversationsTypes.SetFocus,


### PR DESCRIPTION
Bug 1: When the message list is short, the message history will fetch twice, leading to duplicated messages.

Bug 2: When the message list is short, it will keep fetching message history although there is none.